### PR TITLE
Tasks、Home画面修正

### DIFF
--- a/src/app/Http/Controllers/TaskController.php
+++ b/src/app/Http/Controllers/TaskController.php
@@ -3,20 +3,21 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use App\Models\Task;
 
 class TaskController extends Controller
 {
     public function index()
     {
-        $tasks = Task::all();
-        
-        $thinking = $tasks->where('priority', '0');
-        $doing = $tasks->where('priority', '1');
-        $done = $tasks->where('priority', '2');
+        $thinking = Task::where('priority', '0')
+            ->where('user_id', Auth::id())->get();
+        $doing = Task::where('priority', '1')
+            ->where('user_id', Auth::id())->get();
+        $done = Task::where('priority', '2')
+            ->where('user_id', Auth::id())->get();
 
         return view('tasks/tasks')
-            ->with('tasks', $tasks)
             ->with('thinking', $thinking)
             ->with('doing', $doing)
             ->with('done', $done);
@@ -29,6 +30,7 @@ class TaskController extends Controller
             'title' => 'required',
             'contents' => 'required'
         ]);
+        $request->merge(['user_id' => Auth::id()]);
         $tasks->fill($request->all())->save();
         return redirect()->route('tasks');
     }

--- a/src/app/Models/Task.php
+++ b/src/app/Models/Task.php
@@ -12,9 +12,10 @@ class Task extends Model
     use SoftDeletes;
 
     protected $fillable = [
+        'user_id',
         'priority',
         'title',
         'contents',
-        'timer'
+        'timer',
     ];
 }

--- a/src/app/Providers/RouteServiceProvider.php
+++ b/src/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,8 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/dashboard';
+    public const HOME = '/';
+    public const Dashboard = '/dashboard';
 
     /**
      * The controller namespace for the application.

--- a/src/database/migrations/2022_03_23_065220_create_tasks_table.php
+++ b/src/database/migrations/2022_03_23_065220_create_tasks_table.php
@@ -15,11 +15,12 @@ class CreateTasksTable extends Migration
     {
         Schema::create('tasks', function (Blueprint $table) {
             $table->bigIncrements('tasks_id');
-            $table->unsignedBigInteger('users_id')->nullable();
+            $table->foreignId('user_id')->constrained('users');
             $table->unsignedInteger('priority');
             $table->string('title', 30);
             $table->string('contents');
             $table->date('deadline')->nullable();
+            
             $table->timestamps();
         });
     }

--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -1132,8 +1132,8 @@ input:checked + .toggle-bg {
 .h-4 {
   height: 1rem;
 }
-.h-72 {
-  height: 18rem;
+.h-80 {
+  height: 20rem;
 }
 .h-16 {
   height: 4rem;
@@ -1159,8 +1159,8 @@ input:checked + .toggle-bg {
 .h-8 {
   height: 2rem;
 }
-.h-80 {
-  height: 20rem;
+.h-72 {
+  height: 18rem;
 }
 .h-9 {
   height: 2.25rem;
@@ -1183,8 +1183,8 @@ input:checked + .toggle-bg {
 .w-4 {
   width: 1rem;
 }
-.w-64 {
-  width: 16rem;
+.w-72 {
+  width: 18rem;
 }
 .w-20 {
   width: 5rem;
@@ -1201,8 +1201,8 @@ input:checked + .toggle-bg {
 .w-8 {
   width: 2rem;
 }
-.w-72 {
-  width: 18rem;
+.w-64 {
+  width: 16rem;
 }
 .w-1\/2 {
   width: 50%;
@@ -1369,9 +1369,6 @@ input:checked + .toggle-bg {
 }
 .overflow-x-hidden {
   overflow-x: hidden;
-}
-.overflow-x-scroll {
-  overflow-x: scroll;
 }
 .overflow-y-scroll {
   overflow-y: scroll;
@@ -1644,6 +1641,9 @@ input:checked + .toggle-bg {
 .pb-6 {
   padding-bottom: 1.5rem;
 }
+.pb-2 {
+  padding-bottom: 0.5rem;
+}
 .pt-3 {
   padding-top: 0.75rem;
 }
@@ -1679,9 +1679,6 @@ input:checked + .toggle-bg {
 }
 .pt-16 {
   padding-top: 4rem;
-}
-.pb-2 {
-  padding-bottom: 0.5rem;
 }
 .text-center {
   text-align: center;

--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -1048,17 +1048,20 @@ input:checked + .toggle-bg {
 .-mr-2 {
   margin-right: -0.5rem;
 }
-.mb-6 {
-  margin-bottom: 1.5rem;
-}
-.mt-2 {
-  margin-top: 0.5rem;
-}
 .mb-4 {
   margin-bottom: 1rem;
 }
 .mt-4 {
   margin-top: 1rem;
+}
+.ml-4 {
+  margin-left: 1rem;
+}
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+.mt-2 {
+  margin-top: 0.5rem;
 }
 .ml-2 {
   margin-left: 0.5rem;
@@ -1068,9 +1071,6 @@ input:checked + .toggle-bg {
 }
 .mr-2 {
   margin-right: 0.5rem;
-}
-.ml-4 {
-  margin-left: 1rem;
 }
 .mt-8 {
   margin-top: 2rem;
@@ -1144,6 +1144,9 @@ input:checked + .toggle-bg {
 .h-6 {
   height: 1.5rem;
 }
+.h-20 {
+  height: 5rem;
+}
 .h-screen {
   height: 100vh;
 }
@@ -1152,9 +1155,6 @@ input:checked + .toggle-bg {
 }
 .h-3\/4 {
   height: 75%;
-}
-.h-20 {
-  height: 5rem;
 }
 .h-8 {
   height: 2rem;
@@ -9902,9 +9902,6 @@ readers do not read off random characters that represent icons */
 .active\:bg-gray-900:active {
   --tw-bg-opacity: 1;
   background-color: rgb(17 24 39 / var(--tw-bg-opacity));
-}
-.active\:pt-1:active {
-  padding-top: 0.25rem;
 }
 .active\:text-gray-700:active {
   --tw-text-opacity: 1;

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -5059,7 +5059,7 @@ function HomeEvent() {
         timerDisplay.setAttribute('data-timer-amount', remain);
         var hour = Math.floor(remain / (60 * 1000));
         var min = Math.floor(remain % (60 * 1000) / 1000);
-        timerDisplay.textContent = ('0' + hour).slice(-2) + ':' + ('0' + min).slice(-2);
+        timerDisplay.textContent = hour + ':' + ('0' + min).slice(-2);
 
         if (remain < 1) {
           clearInterval(intervalId);
@@ -5114,12 +5114,14 @@ function HomeEvent() {
             return response.json();
           }).then(function (data) {
             if (data["timer"]) {
-              timerDisplay.textContent = ('0' + data["timer"]).slice(-2) + ':00';
+              timerDisplay.textContent = data["timer"] + ':00';
               timerDisplay.setAttribute('data-timer-amount', data["timer"] * 60);
             } else {
               timerDisplay.textContent = '60:00';
               timerDisplay.setAttribute('data-timer-amount', '1800');
             }
+
+            $('#task-title').text(data["title"]);
           })["catch"](function (err) {
             alert('通信に失敗しました。');
           });

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -5177,7 +5177,10 @@ function TaskEvent() {
         var taskId = dragEl.getAttribute('data-taskId');
         var url = '/tasks/softDelete/' + taskId;
         fetch(url, {
-          method: 'GET'
+          method: 'POST',
+          headers: {
+            'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+          }
         }).then(function (response) {
           return response.json();
         }).then(function (data) {
@@ -5233,8 +5236,10 @@ function TaskEvent() {
             task.classList.add('hidden');
             var url = '/tasks/softDelete/' + taskId;
             fetch(url, {
+              method: 'POST',
               headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
               }
             }).then(function (response) {
               return response.json();

--- a/src/resources/js/home.js
+++ b/src/resources/js/home.js
@@ -18,7 +18,7 @@ export function HomeEvent() {
         timerDisplay.setAttribute('data-timer-amount', remain);
         let hour = Math.floor(remain / (60 * 1000));
         let min = Math.floor((remain % (60 * 1000)) / 1000);
-        timerDisplay.textContent = ('0' + hour).slice(-2) + ':' + ('0' + min).slice(-2);
+        timerDisplay.textContent = hour + ':' + ('0' + min).slice(-2);
         if (remain < 1) {
           clearInterval(intervalId);
           document.querySelector('#finish-icon').classList.remove('hidden');
@@ -60,12 +60,13 @@ export function HomeEvent() {
         .then(response => response.json())
         .then(data => {
           if (data["timer"]) {
-              timerDisplay.textContent = ('0' + data["timer"]).slice(-2) + ':00';
-              timerDisplay.setAttribute('data-timer-amount', data["timer"] * 60);
+            timerDisplay.textContent = data["timer"] + ':00';
+            timerDisplay.setAttribute('data-timer-amount', data["timer"] * 60);
           } else {
-              timerDisplay.textContent = '60:00'
-              timerDisplay.setAttribute('data-timer-amount', '1800');
+            timerDisplay.textContent = '60:00'
+            timerDisplay.setAttribute('data-timer-amount', '1800');
           }
+          $('#task-title').text(data["title"]);
         })
         .catch(err => {
           alert('通信に失敗しました。')

--- a/src/resources/js/tasks.js
+++ b/src/resources/js/tasks.js
@@ -24,8 +24,12 @@ export function TaskEvent(){
         dragEl.remove();
         let taskId = dragEl.getAttribute('data-taskId');
         let url = '/tasks/softDelete/' + taskId;
+
         fetch(url, {
-            method: 'GET'
+            method: 'POST',
+            headers: {
+              'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+            }
         })
         .then(response => response.json())
         .then(data => console.log(data))
@@ -74,8 +78,10 @@ export function TaskEvent(){
 
           const url = '/tasks/softDelete/' + taskId;
           fetch(url, {
+            method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
+              'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
             }
           })
           .then(response => response.json())

--- a/src/resources/views/home.blade.php
+++ b/src/resources/views/home.blade.php
@@ -18,7 +18,7 @@
                     <p id="timer-display" class="text-6xl absolute top-80" data-timer-amount="{{ $tasks[0]->timer * 60 }}">
                         {{ $tasks[0]->timer }}:00
                     </p>
-                @else 
+                @else
                     <p id="timer-display" class="text-6xl absolute top-80" data-timer-amount="3600">
                         60:00 (仮)
                     </p>
@@ -35,7 +35,8 @@
                 <div class="animate-ping h-4 w-4 bg-blue-600 rounded-full"></div>
             </div>
         </div>
-        <div class="flex justify-center pt-24">
+        <p class="text-center text-2xl font-bold pt-12" id="task-title">{{ $tasks[0]->title }}</p>
+        <div class="flex justify-center pt-12">
             <button id="time-button" class="text-white rounded px-3 py-2 bg-blue-600 active:bg-blue-900">start</button>
         </div>
     </div>

--- a/src/resources/views/home.blade.php
+++ b/src/resources/views/home.blade.php
@@ -13,15 +13,24 @@
             <div id="spin" class="h-96 w-96 border border-8 rounded-full flex justify-center items-center bg-white relative">
                 <div class="absolute -top-6 border rounded-full bg-gray-400 w-12 h-12"></div>
             </div>
-            @if ($tasks[0]->timer)
-                <p id="timer-display" class="text-6xl absolute top-80" data-timer-amount="{{ $tasks[0]->timer * 60 }}">
-                    {{ $tasks[0]->timer }}:00
-                </p>
-            @else 
+            @auth
+                @isset ($tasks[0]->timer)
+                    <p id="timer-display" class="text-6xl absolute top-80" data-timer-amount="{{ $tasks[0]->timer * 60 }}">
+                        {{ $tasks[0]->timer }}:00
+                    </p>
+                @else 
+                    <p id="timer-display" class="text-6xl absolute top-80" data-timer-amount="3600">
+                        60:00 (仮)
+                    </p>
+                @endisset
+            @endauth
+
+            @guest
                 <p id="timer-display" class="text-6xl absolute top-80" data-timer-amount="3600">
                     60:00 (仮)
                 </p>
-            @endif
+            @endguest
+
             <div id="finish-icon" class="flex justify-center my-20 hidden">
                 <div class="animate-ping h-4 w-4 bg-blue-600 rounded-full"></div>
             </div>

--- a/src/resources/views/layouts/template.blade.php
+++ b/src/resources/views/layouts/template.blade.php
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Eigoの勉強</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="stylesheet" href="{{ mix('css/app.css') }}">
     <script src="{{ mix('js/app.js') }}"></script>
     <script src="https://unpkg.com/flowbite@1.4.1/dist/flowbite.js"></script>

--- a/src/resources/views/layouts/template.blade.php
+++ b/src/resources/views/layouts/template.blade.php
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="utf-8">
-    <title>Eigoの勉強</title>
+    <title>Katask</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="stylesheet" href="{{ mix('css/app.css') }}">
@@ -12,7 +12,7 @@
 <body class="h-screen">
     <header class="border px-3 py-2 bg-blue-200 shadow fixed w-full">
         <nav class="flex items-center">
-            <p class="text-4xl px-4"><a href="/">Eigoの勉強</a></p>
+            <p class="text-4xl px-4"><a href="/">Katask</a></p>
             <ul class="flex">
                             
                 @auth

--- a/src/resources/views/tasks/tasks.blade.php
+++ b/src/resources/views/tasks/tasks.blade.php
@@ -18,7 +18,7 @@
                         <p class="text-2xl text-center">検討中のTask</p>
                         <div class="task-index" data-priority-id='0'>
                             @foreach ($thinking as $item)
-                                <div class="active:pt-1 task" data-taskId="{{$item->tasks_id}}">
+                                <div class="task" data-taskId="{{$item->tasks_id}}">
                                     <div class="mx-3 my-1 p-2 border rounded-md active:bg-gray-100 shadow">
                                         <p>{{ $item->title }}</p>
                                         <p class="hidden whitespace-pre-wrap task-contents mx-3 my-1 p-1">{{ $item->contents }}</p>
@@ -36,7 +36,7 @@
                         <p class="text-2xl text-center">実行中のTask</p>
                         <div class="task-index" data-priority-id='1'>
                             @foreach ($doing as $item)
-                                <div class="active:pt-1 task" data-taskId="{{$item->tasks_id}}">
+                                <div class="task" data-taskId="{{$item->tasks_id}}">
                                     <div class="mx-3 my-1 p-2 border rounded-md active:bg-gray-100 shadow">
                                         <p>{{ $item->title }}</p>
                                         <p class="hidden whitespace-pre-wrap task-contents mx-3 my-1 p-1">{{ $item->contents }}</p>
@@ -54,7 +54,7 @@
                         <p class="text-2xl text-center">完了したTask</p>
                         <div class="task-index" data-priority-id='2'>
                             @foreach ($done as $item)
-                                <div class="active:pt-1 task" data-taskId="{{$item->tasks_id}}">
+                                <div class="task" data-taskId="{{$item->tasks_id}}">
                                     <div class="mx-3 my-1 p-2 border rounded-md active:bg-gray-100 shadow">
                                         <p>{{ $item->title }}</p>
                                         <p class="hidden whitespace-pre-wrap task-contents mx-3 my-1 p-1">{{ $item->contents }}</p>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -21,21 +21,22 @@ use App\Http\Controllers\HomeController;
 Route::get('/', [HomeController::class, 'index'])->name('home');
 Route::get('/home/{id}', [HomeController::class, 'setTimer'])->name('setTimer');
 
-// UserController
-Route::get('/mypage', [UserController::class, 'index'])->name('mypage');
+// TaskController, StatusController,UserController
+Route::middleware(['auth'])->group(function() {
+    Route::controller(TaskController::class)->group(function() {
+        Route::get('/tasks', 'index')->name('tasks');
+        Route::post('/tasks/softDelete/{id}', 'softDelete')->name('tasks-softDelete'); // postにする必要ないので後修正
+        Route::get('/tasks/trashcan', 'trashcan')->name('trashcan');
+        Route::get('/tasks/restore', 'restore')->name('restore');
+        Route::get('/tasks/forceDelete', 'forceDelete')->name('forceDelete');
+        Route::get('/tasks/update/{id}/{priority_id}', 'update')->name('tasks-update');
+        Route::post('/tasks/store', 'store')->name('tasks-store');
+    });
 
-// StatusController
-Route::get('/status', [StatusController::class, 'index'])->name('status');
+    Route::get('/status', [StatusController::class, 'index'])->name('status');
 
-// TasksController
-Route::get('/tasks', [TaskController::class, 'index'])->name('tasks');
-Route::get('/tasks/softDelete/{id}', [TaskController::class, 'softDelete'])->name('tasks-softDelete');
-Route::get('/tasks/trashcan', [TaskController::class, 'trashcan'])->name('trashcan');
-Route::get('/tasks/restore', [TaskController::class, 'restore'])->name('restore');
-Route::get('/tasks/forceDelete', [TaskController::class, 'forceDelete'])->name('forceDelete');
-Route::get('/tasks/update/{id}/{priority_id}', [TaskController::class, 'update'])->name('tasks-update');
-Route::post('/tasks/store', [TaskController::class, 'store'])->name('tasks-store');
-
+    Route::get('/mypage', [UserController::class, 'index'])->name('mypage');
+});
 
 Route::get('/dashboard', function () {
     return view('dashboard');


### PR DESCRIPTION
# 概要

TasksとHome画面の大幅修正。
その他修正。

## Home

Homeにて現在のタスクタイトル名を表示
Homeにて三桁の数字が二桁に切り捨てられてしまうことの修正
認証後トップページに遷移するよう修正
トップページにてデータがない場合にエラーになる問題の修正
titleタグとアプリ表示名変更

## Tasks

tasksレコードのuser_idにセッションユーザーが入るよう修正
非同期post通信時にcsrfトークンを付与
task画面にてクリック時にpaddingがかかるのをキャンセル

## ルーティング

authミドルウェアを挟むことで認証済みユーザーのみがアクセスできるよう変更。
一部コントローラーごとで管理するよう書き方を修正。